### PR TITLE
Moved in stuff from event_loop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "pistoncore-window"
-version = "0.0.9"
+version = "0.0.10"
 authors = [
     "bvssvni <bvssvni@gmail.com>",
     "Coeuvre <coeuvre@gmail.com>"
@@ -22,11 +22,6 @@ path = "src/lib.rs"
 git = "https://github.com/pistondevelopers/input"
 #version = "0.0.5"
 
-[dependencies.pistoncore-event_loop]
-git = "https://github.com/pistondevelopers/event_loop"
-#version = "0.0.11"
-
 [dependencies.quack]
 git = "https://github.com/pistondevelopers/quack"
 #version = "0.0.12"
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,13 +6,101 @@
 extern crate input;
 #[macro_use]
 extern crate quack;
-extern crate event_loop;
 
 use input::Input;
-use quack::{ Associative, Get };
+use quack::{ ActOn, Action, Associative, Get, GetFrom, Pair };
 
-// Reexport everything from event_loop.
-pub use event_loop::*;
+/// Required to use the event loop.
+pub trait Window {
+    type Event;
+
+    /// Returns true if window should close.
+    fn should_close(&self) -> bool;
+
+    /// Gets the size of the window in user coordinates.
+    fn size(&self) -> [u32; 2];
+
+    /// Swaps render buffers.
+    fn swap_buffers(&mut self);
+
+    /// Polls event from window.
+    fn poll_event(&mut self) -> Option<Self::Event>;
+}
+
+impl<T> Window for T
+    where
+        (PollEvent, T): Pair<Data = PollEvent, Object = T>
+            + Associative
+            + ActOn<Result = Option<<(PollEvent, T) as quack::Associative>::Type>>,
+        (ShouldClose, T): Pair<Data = ShouldClose, Object = T>
+            + GetFrom,
+        (SwapBuffers, T): Pair<Data = SwapBuffers, Object = T>
+            + ActOn,
+        (Size, T): Pair<Data = Size, Object = T>
+            + GetFrom
+{
+    type Event = <(PollEvent, T) as Associative>::Type;
+
+    #[inline(always)]
+    fn should_close(&self) -> bool {
+        let ShouldClose(val) = self.get();
+        val
+    }
+
+    #[inline(always)]
+    fn size(&self) -> [u32; 2] {
+        let Size(size) = self.get();
+        size
+    }
+
+    #[inline(always)]
+    fn swap_buffers(&mut self) {
+        self.action(SwapBuffers);
+    }
+
+    #[inline(always)]
+    fn poll_event(&mut self) -> Option<<Self as Window>::Event> {
+        self.action(PollEvent)
+    }
+}
+
+/// Whether window should close or not.
+#[derive(Copy)]
+pub struct ShouldClose(pub bool);
+
+impl Sized for ShouldClose {}
+
+/// The size of the window.
+#[derive(Copy)]
+pub struct Size(pub [u32; 2]);
+
+impl Sized for Size {}
+
+/// Tells window to swap buffers.
+///
+/// ~~~ignore
+/// use current::Action;
+///
+/// ...
+/// window.action(SwapBuffers);
+/// ~~~
+#[derive(Copy)]
+pub struct SwapBuffers;
+
+impl Sized for SwapBuffers {}
+
+/// Polls event from window.
+///
+/// ~~~ignore
+/// use current::Action;
+///
+/// ...
+/// let e = window.action(PollEvent);
+/// ~~~
+#[derive(Copy)]
+pub struct PollEvent;
+
+impl Sized for PollEvent {}
 
 /// The title of the window.
 pub struct Title(pub String);
@@ -116,4 +204,3 @@ action:
 impl Associative for (PollEvent, NoWindow) {
     type Type = Input;
 }
-


### PR DESCRIPTION
Closes https://github.com/PistonDevelopers/window/issues/33

Will break Travis CI because dependencies are reversed, must be restarted after updating event_loop.