### PR TITLE
Depend only on crates.io libraries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,7 @@ homepage = "https://github.com/pistondevelopers/window"
 name = "window"
 path = "src/lib.rs"
 
-[dependencies.pistoncore-input]
-git = "https://github.com/pistondevelopers/input"
-#version = "0.0.9"
-
 [dependencies]
+
 libc = "0.1"
+pistoncore-input = "0.0.9"


### PR DESCRIPTION
Addresses PistonDevelopers/piston#891.